### PR TITLE
Added support for seperate GNOME Shell Theme

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -100,6 +100,9 @@ config["firefoxEnabled"] = False
 config["firefoxDarkTheme"] = "firefox-compact-dark@mozilla.org"
 config["firefoxLightTheme"] = "firefox-compact-light@mozilla.org"
 config["firefoxActiveTheme"] = "firefox-compact-light@mozilla.org"
+config["gnomeEnabled"] = False
+config["gnomeLightTheme"] = ""
+config["gnomeDarkTheme"] = ""
 
 
 if exists():
@@ -238,3 +241,16 @@ def code_get_dark_theme():
 
 def code_get_checkbox():
     return config["codeEnabled"]
+
+def gnome_get_light_theme():
+    """Return the  Gnome Shell Light theme specified in the yin-yang config"""
+    return config["gnomeLightTheme"]
+
+
+def gnome_get_dark_theme():
+    """Return the  Gnome Shell dark theme specified in the yin-yang config"""
+    return config["gnomeDarkTheme"]
+
+
+def gnome_get_checkbox():
+    return config["gnomeEnabled"]

--- a/src/plugins/gnome.py
+++ b/src/plugins/gnome.py
@@ -1,0 +1,13 @@
+import subprocess
+from src import config
+
+# WIP: Potential Check  for https://gist.github.com/atiensivu/fcc3183e9a6fd74ec1a283e3b9ad05f0 to reduce common issues, or write it in the FAQ
+
+def switch_to_light():
+    gnome_theme = config.get("gnomeLightTheme")
+    subprocess.run(["gsettings", "set", "org.gnome.shell.extensions.user-theme", "name", '"{}"'.format(gnome_theme)]) # Shell theme
+
+
+def switch_to_dark():
+    gnome_theme = config.get("gnomeDarkTheme")
+    subprocess.run(["gsettings", "set", "org.gnome.shell.extensions.user-theme", "name", '"{}"'.format(gnome_theme)]) # Shell theme

--- a/src/plugins/gtk.py
+++ b/src/plugins/gtk.py
@@ -7,11 +7,11 @@ def switch_to_light():
     # gtk_theme = "Default"
     # uses a kde api to switch to a light theme
     subprocess.run(["gsettings", "set", "org.gnome.desktop.interface", "gtk-theme", gtk_theme]) # Applications theme
-    subprocess.run(["gsettings", "set", "org.gnome.shell.extensions.user-theme", "name", '"{}"'.format(gtk_theme)]) # Shell theme
+    #subprocess.run(["gsettings", "set", "org.gnome.shell.extensions.user-theme", "name", '"{}"'.format(gtk_theme)]) # Shell theme
 
 
 def switch_to_dark():
     gtk_theme = config.get("gtkDarkTheme")
     # uses a kde api to switch to a dark theme
     subprocess.run(["gsettings", "set", "org.gnome.desktop.interface", "gtk-theme", gtk_theme]) # Applications theme
-    subprocess.run(["gsettings", "set", "org.gnome.shell.extensions.user-theme", "name", '"{}"'.format(gtk_theme)]) # Shell theme
+    #subprocess.run(["gsettings", "set", "org.gnome.shell.extensions.user-theme", "name", '"{}"'.format(gtk_theme)]) # Shell theme

--- a/src/yin_yang.py
+++ b/src/yin_yang.py
@@ -19,7 +19,7 @@ import pwd
 import datetime
 import subprocess
 from src import gui
-from src.plugins import kde, gtkkde, wallpaper, vscode, atom, gtk, firefox
+from src.plugins import kde, gtkkde, wallpaper, vscode, atom, gtk, firefox, gnome
 from src import config
 
 
@@ -48,6 +48,8 @@ class Yang(threading.Thread):
             gtkkde.switch_to_light()
         if config.get("gtkEnabled") and config.get("desktop") == "gtk":
             gtk.switch_to_light()
+        if config.get("gnomeEnabled"):
+            gnome.switch_to_light()
         if config.get("firefoxEnabled"):
             firefox.switch_to_light()
         play_sound("./assets/light.wav")
@@ -78,6 +80,10 @@ class Yin(threading.Thread):
         # gnome and budgie support
         if config.get("gtkEnabled") and config.get("desktop") == "gtk":
             gtk.switch_to_dark()
+
+        # gnome-shell
+        if config.get("gnomeEnabled"):
+            gnome.switch_to_dark()
         
         # firefox support
         if config.get("firefoxEnabled"):


### PR DESCRIPTION
Im unsure why you are trying to set `org.gnome.shell.extensions.user-theme name` to the users gtk theme, because they are different. It messes up the GNOME Shell theme of the users that have set it over the "User-Themes" extension.

In this PR i've tried to mitigate this Issue by creating a separate gnome plugin. It works for me, but at this time you have to change the settings in the `~/.config/yin-yang/yin-yang.json` (see 
![image](https://user-images.githubusercontent.com/31540351/80127448-dd67d180-8583-11ea-94aa-3d43bb43fe5c.png)
) because I have no clue how to use qt.
