### PR TITLE
[👌 IMPROVE] use $HOME rather than $USER and $SUDO_USER for robustness

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,21 +26,21 @@ echo ""
 echo "Checking and creating correct folders ..."
 #check if /opt/ directory exists else create
 if [ ! -d /opt/ ]; then
-    mkdir /opt/
+    mkdir -p /opt/
 fi
 #check if /opt/ directory exists else create
 if [ ! -d /opt/yin-yang/ ]; then
-    mkdir /opt/yin-yang/
+    mkdir -p /opt/yin-yang/
 fi
 # check directories for extension
 if [ ! -d /usr/lib/mozilla ]; then
-    mkdir /usr/lib/mozilla
+    mkdir -p /usr/lib/mozilla
 fi
 if [ ! -d /usr/lib/mozilla/native-messaging-hosts/ ]; then
-    mkdir /usr/lib/mozilla/native-messaging-hosts/
+    mkdir -p /usr/lib/mozilla/native-messaging-hosts/
 fi
-if [ ! -d /home/$SUDO_USER/.local/share/applications/ ]; then
-    mkdir /home/$SUDO_USER/.local/share/applications/
+if [ ! -d "${YIN_YANG_HOME}/.local/share/applications/" ]; then
+    mkdir -p "${YIN_YANG_HOME}/.local/share/applications/"
 fi
 echo ""
 echo "done"


### PR DESCRIPTION
Hello,

Thank you so much for accepting #55. I've tested `./install.sh` and `./uninstall.sh` and they work well on my weird setup. Except for one place where `SUDO_USER` is still used which I think was introduced after the PR was opened. So this fixes that. I will also watch the repository for any future opened issues regarding this and address them.

Also included in this PR, could we use `mkdir -p` to generate the entire hierarchy? For example, without `-p`, `mkdir /usr/lib/mozilla/native-messaging-hosts/` will fail if `/usr/lib/mozilla` is not created.

Kind regards!