### PR TITLE
Add checkbox to toggle switching sound

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,8 @@ from src import gui
 from PyQt5 import QtWidgets
 from PyQt5 import QtCore
 
+assembly_version = 2.0
+
 # fix HiDpi scaling
 QtWidgets.QApplication.setAttribute(
     QtCore.Qt.AA_EnableHighDpiScaling, True)
@@ -30,6 +32,11 @@ def main():
                         help="schedule theme toggl, starts daemon in bg",
                         action="store_true")
     args = parser.parse_args()
+
+    # Check and see if there are new keys we need to add to the config.
+    should_update_config = assembly_version != config.get_version()
+    if should_update_config:
+        update_config()
 
     # checks wether $ yin-yang is ran without args
     if len(sys.argv) == 1 and not args.toggle:
@@ -59,6 +66,12 @@ def main():
     # gui is set as parameter
     if args.toggle:
         toggle_theme()
+
+# This method is called to add keys to the config
+# which have been added since version 1.0
+def update_config():
+    if not "soundEnabled" in config.config:
+        config.config["soundEnabled"] = True
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from src import gui
 from PyQt5 import QtWidgets
 from PyQt5 import QtCore
 
-assembly_version = 2.0
+assembly_version = 2.1
 
 # fix HiDpi scaling
 QtWidgets.QApplication.setAttribute(
@@ -73,6 +73,8 @@ def main():
 def update_config():
     if not "soundEnabled" in config.config:
         config.config["soundEnabled"] = True
+
+    config.update("version", assembly_version)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -29,7 +29,7 @@ def main():
                         help="toggles Yin-Yang",
                         action="store_true")
     parser.add_argument("-s", "--schedule",
-                        help="schedule theme toggl, starts daemon in bg",
+                        help="schedule theme toggle, starts daemon in bg",
                         action="store_true")
     args = parser.parse_args()
 
@@ -38,7 +38,7 @@ def main():
     if should_update_config:
         update_config()
 
-    # checks wether $ yin-yang is ran without args
+    # checks whether $ yin-yang is ran without args
     if len(sys.argv) == 1 and not args.toggle:
         # load GUI
         app = QtWidgets.QApplication(sys.argv)
@@ -46,11 +46,11 @@ def main():
         window.show()
         sys.exit(app.exec_())
 
-    # checks wether the script should be ran as a daemon
+    # checks whether the script should be ran as a daemon
     if args.schedule:
         config.update("running", False)
         print("START thread listener")
-        
+
         if config.get("followSun"):
             # calculate time if needed
             config.set_sun_time()
@@ -66,6 +66,7 @@ def main():
     # gui is set as parameter
     if args.toggle:
         toggle_theme()
+
 
 # This method is called to add keys to the config
 # which have been added since version 1.0

--- a/src/config.py
+++ b/src/config.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import re
 
+from main import assembly_version
 from suntime import Sun, SunTimeException
 
 # aliases for path to use later on
@@ -68,7 +69,7 @@ pathlib.Path(path + "/yin_yang").mkdir(parents=True, exist_ok=True)
 
 # if there is no config generate a generic one
 config = {}
-config["version"] = "2.0"
+config["version"] = assembly_version
 config["desktop"] = get_desktop()
 config["followSun"] = False
 config["latitude"] = ""

--- a/src/config.py
+++ b/src/config.py
@@ -104,6 +104,7 @@ config["gnomeDarkTheme"] = ""
 config["kvantumEnabled"] = False
 config["kvantumLightTheme"] = ""
 config["kvantumDarkTheme"] = ""
+config["soundEnabled"] = True
 
 
 if exists():
@@ -152,7 +153,6 @@ def get_dark_time():
 
 def get_theme():
     return config["theme"]
-
 
 def get_kde_light_theme():
     return config["kdeLightTheme"]
@@ -226,6 +226,8 @@ def gtk_get_dark_theme():
     """Return the  GTK dark theme specified in the yin-yang config"""
     return config["gtkDarkTheme"]
 
+def sound_get_checkbox():
+    return config["soundEnabled"]
 
 def gtk_get_checkbox():
     return config["gtkEnabled"]

--- a/src/config.py
+++ b/src/config.py
@@ -1,8 +1,8 @@
 import json
-import pwd
 import os
 import pathlib
 import re
+
 from suntime import Sun, SunTimeException
 
 # aliases for path to use later on
@@ -11,13 +11,13 @@ path = home + "/.config"
 
 
 def exists():
-    """returns True or False wether Config exists or note"""
+    """returns True or False whether Config exists"""
     return os.path.isfile(path + "/yin_yang/yin_yang.json")
 
 
 def get_desktop():
-    """Return the current desktop's name or 'unkown' if can't determine it"""
-    # just to get all possible implementations of dekstop variables
+    """Return the current desktops name or 'unknown' if can't determine it"""
+    # just to get all possible implementations of desktop variables
     env = str(os.getenv("GDMSESSION")).lower()
     second_env = str(os.getenv("XDG_CURRENT_DESKTOP")).lower()
     third_env = str(os.getenv("XDG_CURRENT_DESKTOP")).lower()

--- a/src/config.py
+++ b/src/config.py
@@ -12,7 +12,7 @@ path = home + "/.config"
 
 def exists():
     """returns True or False wether Config exists or note"""
-    return os.path.isfile(path+"/yin_yang/yin_yang.json")
+    return os.path.isfile(path + "/yin_yang/yin_yang.json")
 
 
 def get_desktop():
@@ -64,8 +64,7 @@ def set_sun_time():
 
 
 # generate path for yin-yang if there is none this will be skipped
-pathlib.Path(path+"/yin_yang").mkdir(parents=True, exist_ok=True)
-
+pathlib.Path(path + "/yin_yang").mkdir(parents=True, exist_ok=True)
 
 # if there is no config generate a generic one
 config = {}
@@ -106,10 +105,9 @@ config["kvantumLightTheme"] = ""
 config["kvantumDarkTheme"] = ""
 config["soundEnabled"] = True
 
-
 if exists():
     # making config global for this module
-    with open(path+"/yin_yang/yin_yang.json", "r") as conf:
+    with open(path + "/yin_yang/yin_yang.json", "r") as conf:
         config = json.load(conf)
 
 config["desktop"] = get_desktop()
@@ -128,12 +126,12 @@ def update(key, value):
 
 def write_config(config=config):
     """Write configuration"""
-    with open(path+"/yin_yang/yin_yang.json", 'w') as conf:
+    with open(path + "/yin_yang/yin_yang.json", 'w') as conf:
         json.dump(config, conf, indent=4)
 
 
 def gtk_exists():
-    return os.path.isfile(path+"/gtk-3.0/settings.ini")
+    return os.path.isfile(path + "/gtk-3.0/settings.ini")
 
 
 def get_enabled_plugins():
@@ -153,6 +151,7 @@ def get_dark_time():
 
 def get_theme():
     return config["theme"]
+
 
 def get_kde_light_theme():
     return config["kdeLightTheme"]
@@ -226,8 +225,10 @@ def gtk_get_dark_theme():
     """Return the  GTK dark theme specified in the yin-yang config"""
     return config["gtkDarkTheme"]
 
+
 def sound_get_checkbox():
     return config["soundEnabled"]
+
 
 def gtk_get_checkbox():
     return config["gtkEnabled"]

--- a/src/gui.py
+++ b/src/gui.py
@@ -17,7 +17,7 @@ class SettingsWindow(QtWidgets.QMainWindow):
         self.setWindowTitle("Settings")
         self.ui = Ui_SettingsWindow()
         self.ui.setupUi(self)
-        # center the settingswindow
+        # center the settings window
         self.center()
         # syncing with config - fill out all fields based on Config
         self.sync_with_config()
@@ -159,7 +159,7 @@ class SettingsWindow(QtWidgets.QMainWindow):
 
         # aliases for path to use later on
         user = pwd.getpwuid(os.getuid())[0]
-        path = "/home/"+user+"/.local/share/plasma/look-and-feel/"
+        path = "/home/" + user + "/.local/share/plasma/look-and-feel/"
 
         # asks the system what themes are available
         long_names = subprocess.check_output(
@@ -280,6 +280,7 @@ class SettingsWindow(QtWidgets.QMainWindow):
         self.ui.kvantum_line_dark.setEnabled(checked)
         config.update("kvantumEnabled", checked)
 
+
 class MainWindow(QtWidgets.QMainWindow):
 
     def __init__(self, parent=None):
@@ -293,7 +294,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self.register_handlers()
         # syncs the UI with the config
         self.sync_with_config()
-
 
     def center(self):
         frame_gm = self.frameGeometry()
@@ -354,7 +354,7 @@ class MainWindow(QtWidgets.QMainWindow):
         Note: this function does not return. Any cleanup action (like
         saving data) must be done before calling this function."""
         python = sys.executable
-        os.execl(python, python, * sys.argv)
+        os.execl(python, python, *sys.argv)
 
     def set_correct_time(self):
         new_config = config.get_config()

--- a/src/gui.py
+++ b/src/gui.py
@@ -294,6 +294,7 @@ class MainWindow(QtWidgets.QMainWindow):
         # syncs the UI with the config
         self.sync_with_config()
 
+
     def center(self):
         frame_gm = self.frameGeometry()
         center_point = QtWidgets.QDesktopWidget().availableGeometry().center()

--- a/src/gui.py
+++ b/src/gui.py
@@ -75,7 +75,7 @@ class SettingsWindow(QtWidgets.QMainWindow):
 
     def sync_with_config(self):
         # sync config label with get the correct version
-        self.ui.version_label.setText("yin-yang: v" + config.get_version())
+        self.ui.version_label.setText("yin-yang: v" + str(config.get_version()))
         # syncing all fields and checkboxes with config
         # ---- KDE -----
         # reads out all kde themes and displays them inside a combobox

--- a/src/gui.py
+++ b/src/gui.py
@@ -307,6 +307,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.ui.dark_push.clicked.connect(self.toggle_dark)
         # connect the settingsButton
         self.ui.settings_push.clicked.connect(self.open_settings)
+        # connect the sound checkbox
+        self.ui.sound_checkBox.clicked.connect(self.toggle_sound)
         # connect the time change with the correct function
         self.ui.light_time.timeChanged.connect(self.time_changed)
         self.ui.dark_time.timeChanged.connect(self.time_changed)
@@ -341,6 +343,10 @@ class MainWindow(QtWidgets.QMainWindow):
         self.sync_with_config()
         # self.restart()
 
+    def toggle_sound(self):
+        config.update("soundEnabled", self.ui.sound_checkBox.isChecked())
+        self.sync_with_config()
+
     # no needed since QT is now used system wise instead of python wise
     def restart(self):
         """Restarts the current program.
@@ -373,6 +379,7 @@ class MainWindow(QtWidgets.QMainWindow):
         if theme == "":
             self.ui.light_push.setEnabled(True)
             self.ui.dark_push.setEnabled(True)
+        self.ui.sound_checkBox.setChecked(config.sound_get_checkbox())
 
     def time_changed(self):
         # update config if time has changed

--- a/src/ui/mainwindow.py
+++ b/src/ui/mainwindow.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'ui/mainwindow.ui'
+# Form implementation generated from reading ui file 'mainwindow.ui'
 #
 # Created by: PyQt5 UI code generator 5.15.0
 #
@@ -37,6 +37,7 @@ class Ui_MainWindow(object):
         self.verticalLayout.setSpacing(6)
         self.verticalLayout.setObjectName("verticalLayout")
         self.yinyang_img = QtWidgets.QLabel(self.verticalLayoutWidget)
+        self.yinyang_img.setEnabled(True)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
         sizePolicy.setHorizontalStretch(128)
         sizePolicy.setVerticalStretch(128)
@@ -52,7 +53,7 @@ class Ui_MainWindow(object):
         self.yinyang_img.setText("")
         self.yinyang_img.setTextFormat(QtCore.Qt.RichText)
         self.yinyang_img.setPixmap(QtGui.QPixmap("assets/icon.png"))
-        self.yinyang_img.setScaledContents(False)
+        self.yinyang_img.setScaledContents(True)
         self.yinyang_img.setAlignment(QtCore.Qt.AlignCenter)
         self.yinyang_img.setObjectName("yinyang_img")
         self.verticalLayout.addWidget(self.yinyang_img, 0, QtCore.Qt.AlignHCenter|QtCore.Qt.AlignVCenter)
@@ -96,6 +97,9 @@ class Ui_MainWindow(object):
         self.dark_time.setObjectName("dark_time")
         self.formLayout.setWidget(1, QtWidgets.QFormLayout.FieldRole, self.dark_time)
         self.verticalLayout.addLayout(self.formLayout)
+        self.sound_checkBox = QtWidgets.QCheckBox(self.verticalLayoutWidget)
+        self.sound_checkBox.setObjectName("sound_checkBox")
+        self.verticalLayout.addWidget(self.sound_checkBox)
         self.settings_push = QtWidgets.QPushButton(self.centralWidget)
         self.settings_push.setGeometry(QtCore.QRect(210, 10, 83, 25))
         self.settings_push.setObjectName("settings_push")
@@ -114,4 +118,5 @@ class Ui_MainWindow(object):
         self.light_time.setDisplayFormat(_translate("MainWindow", "HH:mm"))
         self.label_2.setText(_translate("MainWindow", "Dark:"))
         self.dark_time.setDisplayFormat(_translate("MainWindow", "HH:mm"))
+        self.sound_checkBox.setText(_translate("MainWindow", "Play sound when theme changes"))
         self.settings_push.setText(_translate("MainWindow", "Settings"))

--- a/src/ui/mainwindow.ui
+++ b/src/ui/mainwindow.ui
@@ -210,6 +210,13 @@
        </item>
       </layout>
      </item>
+     <item>
+      <widget class="QCheckBox" name="sound_checkBox">
+       <property name="text">
+        <string>Play sound when theme changes</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </widget>
    <widget class="QPushButton" name="settings_push">

--- a/src/ui/ui.pro.user
+++ b/src/ui/ui.pro.user
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.8.1, 2019-03-06T20:40:55. -->
+<!-- Written by QtCreator 4.13.1, 2020-10-01T15:14:19. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>
-  <value type="QByteArray">{618feedc-e0c9-414f-889e-dfa705f76860}</value>
+  <value type="QByteArray">{01392515-96b8-4c2d-be6e-8250b075eeb2}</value>
  </data>
  <data>
   <variable>ProjectExplorer.Project.ActiveTarget</variable>
@@ -49,43 +49,63 @@
    <value type="bool" key="EditorConfiguration.addFinalNewLine">true</value>
    <value type="bool" key="EditorConfiguration.cleanIndentation">true</value>
    <value type="bool" key="EditorConfiguration.cleanWhitespace">true</value>
+   <value type="QString" key="EditorConfiguration.ignoreFileTypes">*.md, *.MD, Makefile</value>
    <value type="bool" key="EditorConfiguration.inEntireDocument">false</value>
+   <value type="bool" key="EditorConfiguration.skipTrailingWhitespace">true</value>
   </valuemap>
  </data>
  <data>
   <variable>ProjectExplorer.Project.PluginSettings</variable>
   <valuemap type="QVariantMap">
+   <valuemap type="QVariantMap" key="AutoTest.ActiveFrameworks">
+    <value type="bool" key="AutoTest.Framework.Boost">true</value>
+    <value type="bool" key="AutoTest.Framework.Catch">true</value>
+    <value type="bool" key="AutoTest.Framework.GTest">true</value>
+    <value type="bool" key="AutoTest.Framework.QtQuickTest">true</value>
+    <value type="bool" key="AutoTest.Framework.QtTest">true</value>
+   </valuemap>
+   <valuemap type="QVariantMap" key="AutoTest.CheckStates"/>
+   <value type="int" key="AutoTest.RunAfterBuild">0</value>
+   <value type="bool" key="AutoTest.UseGlobal">true</value>
    <valuelist type="QVariantList" key="ClangCodeModel.CustomCommandLineKey"/>
    <value type="bool" key="ClangCodeModel.UseGlobalConfig">true</value>
+   <value type="QString" key="ClangCodeModel.WarningConfigId">Builtin.Questionable</value>
+   <valuemap type="QVariantMap" key="ClangTools">
+    <value type="bool" key="ClangTools.BuildBeforeAnalysis">true</value>
+    <value type="QString" key="ClangTools.DiagnosticConfig">Builtin.DefaultTidyAndClazy</value>
+    <value type="int" key="ClangTools.ParallelJobs">6</value>
+    <valuelist type="QVariantList" key="ClangTools.SelectedDirs"/>
+    <valuelist type="QVariantList" key="ClangTools.SelectedFiles"/>
+    <valuelist type="QVariantList" key="ClangTools.SuppressedDiagnostics"/>
+    <value type="bool" key="ClangTools.UseGlobalSettings">true</value>
+   </valuemap>
   </valuemap>
  </data>
  <data>
   <variable>ProjectExplorer.Project.Target.0</variable>
   <valuemap type="QVariantMap">
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop Qt 5.12.0 GCC 64bit</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop Qt 5.12.0 GCC 64bit</value>
-   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">qt.qt5.5120.gcc_64_kit</value>
+   <value type="QString" key="DeviceType">Desktop</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Desktop (x86-darwin-generic-mach_o-64bit)</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Desktop (x86-darwin-generic-mach_o-64bit)</value>
+   <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">{de127b30-ba62-49c4-b21d-44ba095e9382}</value>
    <value type="int" key="ProjectExplorer.Target.ActiveBuildConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveDeployConfiguration">0</value>
    <value type="int" key="ProjectExplorer.Target.ActiveRunConfiguration">0</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.0">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/daeh/yinyang/yin_yang/build-ui-Desktop_Qt_5_12_0_GCC_64bit-Debug</value>
+    <value type="bool">true</value>
+    <value type="int" key="EnableQmlDebugging">0</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/chase/source/Yin-Yang/src/build-ui-Desktop_x86_darwin_generic_mach_o_64bit-Debug</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/chase/source/Yin-Yang/src/build-ui-Desktop_x86_darwin_generic_mach_o_64bit-Debug</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">qmake</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.LinkQmlDebuggingLibrary">true</value>
       <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
       <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.SeparateDebugInfo">false</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.UseQtQuickCompiler">false</value>
+      <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
      </valuemap>
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.BuildTargets"/>
       <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">false</value>
@@ -95,14 +115,12 @@
      </valuemap>
      <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
     </valuemap>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.BuildTargets"/>
       <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">true</value>
@@ -112,36 +130,34 @@
      </valuemap>
      <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
     </valuemap>
     <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
     <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
     <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Debug</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Debug</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
     <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">2</value>
-    <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
+    <value type="int" key="QtQuickCompiler">2</value>
+    <value type="int" key="SeparateDebugInfo">2</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.1">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/daeh/yinyang/yin_yang/build-ui-Desktop_Qt_5_12_0_GCC_64bit-Release</value>
+    <value type="bool">true</value>
+    <value type="int" key="EnableQmlDebugging">2</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/chase/source/Yin-Yang/src/build-ui-Desktop_x86_darwin_generic_mach_o_64bit-Release</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/chase/source/Yin-Yang/src/build-ui-Desktop_x86_darwin_generic_mach_o_64bit-Release</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">qmake</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.LinkQmlDebuggingLibrary">false</value>
       <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
       <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.SeparateDebugInfo">false</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.UseQtQuickCompiler">true</value>
+      <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
      </valuemap>
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.BuildTargets"/>
       <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">false</value>
@@ -151,14 +167,12 @@
      </valuemap>
      <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
     </valuemap>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.BuildTargets"/>
       <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">true</value>
@@ -168,36 +182,34 @@
      </valuemap>
      <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
     </valuemap>
     <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
     <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
     <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Release</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Release</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
     <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
-    <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
+    <value type="int" key="QtQuickCompiler">0</value>
+    <value type="int" key="SeparateDebugInfo">2</value>
    </valuemap>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.BuildConfiguration.2">
-    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/home/daeh/yinyang/yin_yang/build-ui-Desktop_Qt_5_12_0_GCC_64bit-Profile</value>
+    <value type="bool">true</value>
+    <value type="int" key="EnableQmlDebugging">0</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory">/Users/chase/source/Yin-Yang/src/build-ui-Desktop_x86_darwin_generic_mach_o_64bit-Profile</value>
+    <value type="QString" key="ProjectExplorer.BuildConfiguration.BuildDirectory.shadowDir">/Users/chase/source/Yin-Yang/src/build-ui-Desktop_x86_darwin_generic_mach_o_64bit-Profile</value>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">qmake</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">QtProjectManager.QMakeBuildStep</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.LinkQmlDebuggingLibrary">true</value>
       <value type="QString" key="QtProjectManager.QMakeBuildStep.QMakeArguments"></value>
       <value type="bool" key="QtProjectManager.QMakeBuildStep.QMakeForced">false</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.SeparateDebugInfo">true</value>
-      <value type="bool" key="QtProjectManager.QMakeBuildStep.UseQtQuickCompiler">true</value>
+      <valuelist type="QVariantList" key="QtProjectManager.QMakeBuildStep.SelectedAbis"/>
      </valuemap>
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.1">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.BuildTargets"/>
       <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">false</value>
@@ -207,14 +219,12 @@
      </valuemap>
      <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">2</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Build</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Build</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Build</value>
     </valuemap>
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.1">
      <valuemap type="QVariantMap" key="ProjectExplorer.BuildStepList.Step.0">
       <value type="bool" key="ProjectExplorer.BuildStep.Enabled">true</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Make</value>
-      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
       <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.MakeStep</value>
       <valuelist type="QVariantList" key="Qt4ProjectManager.MakeStep.BuildTargets"/>
       <value type="bool" key="Qt4ProjectManager.MakeStep.Clean">true</value>
@@ -224,34 +234,52 @@
      </valuemap>
      <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">1</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Clean</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Clean</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Clean</value>
     </valuemap>
     <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">2</value>
     <value type="bool" key="ProjectExplorer.BuildConfiguration.ClearSystemEnvironment">false</value>
+    <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.CustomParsers"/>
     <valuelist type="QVariantList" key="ProjectExplorer.BuildConfiguration.UserEnvironmentChanges"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Profile</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Profile</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4BuildConfiguration</value>
     <value type="int" key="Qt4ProjectManager.Qt4BuildConfiguration.BuildConfiguration">0</value>
-    <value type="bool" key="Qt4ProjectManager.Qt4BuildConfiguration.UseShadowBuild">true</value>
+    <value type="int" key="QtQuickCompiler">0</value>
+    <value type="int" key="SeparateDebugInfo">0</value>
    </valuemap>
    <value type="int" key="ProjectExplorer.Target.BuildConfigurationCount">3</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.DeployConfiguration.0">
     <valuemap type="QVariantMap" key="ProjectExplorer.BuildConfiguration.BuildStepList.0">
      <value type="int" key="ProjectExplorer.BuildStepList.StepsCount">0</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy</value>
-     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+     <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName">Deploy</value>
      <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.BuildSteps.Deploy</value>
     </valuemap>
     <value type="int" key="ProjectExplorer.BuildConfiguration.BuildStepListCount">1</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">Deploy Configuration</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
+    <valuemap type="QVariantMap" key="ProjectExplorer.DeployConfiguration.CustomData"/>
+    <value type="bool" key="ProjectExplorer.DeployConfiguration.CustomDataEnabled">false</value>
     <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">ProjectExplorer.DefaultDeployConfiguration</value>
    </valuemap>
    <value type="int" key="ProjectExplorer.Target.DeployConfigurationCount">1</value>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.PluginSettings"/>
    <valuemap type="QVariantMap" key="ProjectExplorer.Target.RunConfiguration.0">
+    <value type="QString" key="Analyzer.Perf.CallgraphMode">dwarf</value>
+    <valuelist type="QVariantList" key="Analyzer.Perf.Events">
+     <value type="QString">cpu-cycles</value>
+    </valuelist>
+    <valuelist type="QVariantList" key="Analyzer.Perf.ExtraArguments"/>
+    <value type="int" key="Analyzer.Perf.Frequency">250</value>
+    <valuelist type="QVariantList" key="Analyzer.Perf.RecordArguments">
+     <value type="QString">-e</value>
+     <value type="QString">cpu-cycles</value>
+     <value type="QString">--call-graph</value>
+     <value type="QString">dwarf,4096</value>
+     <value type="QString">-F</value>
+     <value type="QString">250</value>
+    </valuelist>
+    <value type="QString" key="Analyzer.Perf.SampleMode">-F</value>
+    <value type="bool" key="Analyzer.Perf.Settings.UseGlobalSettings">true</value>
+    <value type="int" key="Analyzer.Perf.StackSize">4096</value>
     <value type="bool" key="Analyzer.QmlProfiler.AggregateTraces">false</value>
     <value type="bool" key="Analyzer.QmlProfiler.FlushEnabled">false</value>
     <value type="uint" key="Analyzer.QmlProfiler.FlushInterval">1000</value>
@@ -266,6 +294,7 @@
     <value type="double" key="Analyzer.Valgrind.Callgrind.MinimumCostRatio">0.01</value>
     <value type="double" key="Analyzer.Valgrind.Callgrind.VisualisationMinimumCostRatio">10</value>
     <value type="bool" key="Analyzer.Valgrind.FilterExternalIssues">true</value>
+    <value type="QString" key="Analyzer.Valgrind.KCachegrindExecutable">kcachegrind</value>
     <value type="int" key="Analyzer.Valgrind.LeakCheckOnFinish">1</value>
     <value type="int" key="Analyzer.Valgrind.NumCallers">25</value>
     <valuelist type="QVariantList" key="Analyzer.Valgrind.RemovedSuppressionFiles"/>
@@ -291,22 +320,23 @@
      <value type="int">13</value>
      <value type="int">14</value>
     </valuelist>
+    <valuelist type="QVariantList" key="CustomOutputParsers"/>
     <value type="int" key="PE.EnvironmentAspect.Base">2</value>
     <valuelist type="QVariantList" key="PE.EnvironmentAspect.Changes"/>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DefaultDisplayName">ui</value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.DisplayName"></value>
-    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/home/daeh/yinyang/yin_yang/ui/ui.pro</value>
-    <value type="QString" key="Qt4ProjectManager.Qt4RunConfiguration.ProFile">ui.pro</value>
+    <value type="QString" key="ProjectExplorer.ProjectConfiguration.Id">Qt4ProjectManager.Qt4RunConfiguration:/Users/chase/source/Yin-Yang/src/ui/ui.pro</value>
+    <value type="QString" key="ProjectExplorer.RunConfiguration.BuildKey">/Users/chase/source/Yin-Yang/src/ui/ui.pro</value>
     <value type="QString" key="RunConfiguration.Arguments"></value>
-    <value type="uint" key="RunConfiguration.QmlDebugServerPort">3768</value>
+    <value type="bool" key="RunConfiguration.Arguments.multi">false</value>
+    <value type="QString" key="RunConfiguration.OverrideDebuggerStartup"></value>
     <value type="bool" key="RunConfiguration.UseCppDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseCppDebuggerAuto">true</value>
+    <value type="bool" key="RunConfiguration.UseDyldImageSuffix">false</value>
     <value type="bool" key="RunConfiguration.UseLibrarySearchPath">true</value>
     <value type="bool" key="RunConfiguration.UseMultiProcess">false</value>
     <value type="bool" key="RunConfiguration.UseQmlDebugger">false</value>
     <value type="bool" key="RunConfiguration.UseQmlDebuggerAuto">true</value>
     <value type="QString" key="RunConfiguration.WorkingDirectory"></value>
-    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/home/daeh/yinyang/yin_yang/build-ui-Desktop_Qt_5_12_0_GCC_64bit-Debug</value>
+    <value type="QString" key="RunConfiguration.WorkingDirectory.default">/Users/chase/source/Yin-Yang/src/build-ui-Desktop_x86_darwin_generic_mach_o_64bit-Debug/ui.app/Contents/MacOS</value>
    </valuemap>
    <value type="int" key="ProjectExplorer.Target.RunConfigurationCount">1</value>
   </valuemap>
@@ -317,10 +347,10 @@
  </data>
  <data>
   <variable>ProjectExplorer.Project.Updater.FileVersion</variable>
-  <value type="int">20</value>
+  <value type="int">22</value>
  </data>
  <data>
   <variable>Version</variable>
-  <value type="int">20</value>
+  <value type="int">22</value>
  </data>
 </qtcreator>

--- a/src/yin_yang.py
+++ b/src/yin_yang.py
@@ -11,21 +11,20 @@ date: 21.12.2018
 license: MIT
 """
 
+import datetime
 import os
+import pwd
+import subprocess
 import sys
 import threading
 import time
-import pwd
-import datetime
-import subprocess
-from src import gui
-from src.plugins import kde, gtkkde, wallpaper, vscode, atom, gtk, firefox, gnome, kvantum
-from src import config
 
+from src import config
+from src.plugins import kde, gtkkde, wallpaper, vscode, atom, gtk, firefox, gnome, kvantum
 
 # aliases for path to use later on
 user = pwd.getpwuid(os.getuid())[0]
-path = "/home/"+user+"/.config/"
+path = "/home/" + user + "/.config/"
 
 terminate = False
 
@@ -91,7 +90,7 @@ class Yin(threading.Thread):
         # kvantum support
         if config.get("kvantumEnabled"):
             kvantum.switch_to_dark()
-        play_sound("/assets/dark.wav")
+        play_sound("./assets/dark.wav")
 
 
 class Daemon(threading.Thread):
@@ -136,6 +135,7 @@ def switch_to_light():
     config.update("theme", "light")
     yang.join()
 
+
 def switch_to_dark():
     yin = Yin(2)
     yin.start()
@@ -146,6 +146,7 @@ def switch_to_dark():
 def start_daemon():
     daemon = Daemon(3)
     daemon.start()
+
 
 def resource_path(relative_path):
     """ Get absolute path to resource, works for dev and for PyInstaller """
@@ -161,7 +162,7 @@ def resource_path(relative_path):
 def play_sound(sound):
     """ Description - only works with pulseaudio.
     :type sound: String (Path)
-    :param sound: Sound path to be played audiofile from
+    :param sound: Sound path to be played audio file from
     :rtype: I hope you will hear your Sound ;)
     """
 
@@ -181,7 +182,7 @@ def should_be_light():
     hour = datetime.datetime.now().time().hour
     minute = datetime.datetime.now().time().minute
 
-    if(hour >= l_hour and hour < d_hour):
+    if hour >= l_hour and hour < d_hour:
         return not (hour == l_hour and minute <= l_minute)
     else:
         return hour == d_hour and minute <= d_minute

--- a/src/yin_yang.py
+++ b/src/yin_yang.py
@@ -165,8 +165,8 @@ def play_sound(sound):
     :rtype: I hope you will hear your Sound ;)
     """
 
-
-    subprocess.run(["paplay", resource_path(sound)])
+    if config.sound_get_checkbox():
+        subprocess.run(["paplay", resource_path(sound)])
 
 
 def should_be_light():


### PR DESCRIPTION
Resolves #54 

This PR adds a checkbox to the main window which allows disabling the sound when changing themes. The config is still set to enable the sound by default for new users to honor the creators original intent, although I personally believe having it disabled by default should be configured.

This is marked WIP as I have not been able to test it on my machine at home yet. I will update once I ensure everything works as intended.